### PR TITLE
Reset role when user logs out

### DIFF
--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -4,13 +4,27 @@ import { db } from "@/lib/firebase";
 import { doc, getDoc } from "firebase/firestore";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
+
+type UserDoc = {
+  role?: "admin" | "manager";
+};
+
 export function useUserRole() {
   const { user } = useAuth();
-  const [role, setRole] = useState<"admin"|"manager"|null>(null);
-  useEffect(() => { (async () => {
-    if (!user) return;
-    const snap = await getDoc(doc(db, "users", user.uid));
-    setRole((snap.data() as any)?.role ?? "manager");
-  })(); }, [user]);
+  const [role, setRole] = useState<"admin" | "manager" | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setRole(null);
+      return;
+    }
+
+    (async () => {
+      const snap = await getDoc(doc(db, "users", user.uid));
+      const data = snap.exists() ? (snap.data() as UserDoc) : null;
+      setRole(data?.role ?? "manager");
+    })();
+  }, [user]);
+
   return role;
 }


### PR DESCRIPTION
## Summary
- clear stored user role when auth user logs out
- type user document and avoid `any`

## Testing
- `npm run lint -- src/hooks/useUserRole.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aeb91eae8883258c79d55c29f56f4e