### PR TITLE
Handle logout with updated user role hook

### DIFF
--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -14,6 +14,8 @@ export function useUserRole() {
   const [role, setRole] = useState<"admin" | "manager" | null>(null);
 
   useEffect(() => {
+    let canceled = false;
+
     if (!user) {
       setRole(null);
       return;
@@ -21,9 +23,14 @@ export function useUserRole() {
 
     (async () => {
       const snap = await getDoc(doc(db, "users", user.uid));
+      if (canceled) return;
       const data = snap.exists() ? (snap.data() as UserDoc) : null;
       setRole(data?.role ?? "manager");
     })();
+
+    return () => {
+      canceled = true;
+    };
   }, [user]);
 
   return role;


### PR DESCRIPTION
## Summary
- reset user role state when the user logs out
- ignore stale Firestore responses when the user changes mid-request

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68af059351e88325aefedd95c7b68b74