### PR TITLE
Use user role for admin links

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,8 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ReactNode, useMemo } from 'react';
-// Facoltativo: se vuoi mostrare link admin solo agli admin, abilita la riga sotto
-// import { useUserRole } from '@/hooks/useUserRole';
+import { useUserRole } from '@/hooks/useUserRole';
 
 type Props = {
   children: ReactNode;
@@ -26,11 +25,8 @@ const navItems: NavItem[] = [
 
 export default function AppShell({ children }: Props) {
   const pathname = usePathname();
-
-  // Facoltativo: mostra link admin solo se ruolo admin
-  // const { role } = useUserRole();
-  // const isAdmin = role === 'admin';
-  const isAdmin = true; // <-- se vuoi sempre visibile, poi rimetti il controllo con useUserRole
+  const { role } = useUserRole();
+  const isAdmin = role === 'admin';
 
   const adminItems: NavItem[] = useMemo(
     () =>

--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -33,5 +33,5 @@ export function useUserRole() {
     };
   }, [user]);
 
-  return role;
+  return { role };
 }


### PR DESCRIPTION
## Summary
- derive admin navigation items based on `useUserRole`
- return role object from `useUserRole`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b755179fe48325ac4bd66ecddccb47