### PR TITLE
Add Rosa link to AppShell navigation

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -20,6 +20,7 @@ const navItems: NavItem[] = [
   { href: '/dashboard', label: 'Dashboard', match: (p) => p === '/dashboard' },
   { href: '/contracts', label: 'Contratti', match: (p) => p === '/contracts' },
   { href: '/stadium', label: 'Stadio', match: (p) => p === '/stadium' },
+  { href: '/rosa', label: 'Rosa', match: (p) => p === '/rosa' },
   { href: '/history', label: 'Storico', match: (p) => p === '/history' },
   { href: '/standings', label: 'Classifica', match: (p) => p === '/standings' },
 ];


### PR DESCRIPTION
## Summary
- add "Rosa" navigation entry to AppShell to access roster page

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors in existing code)*
- `node - <<'NODE'
const navItem = { href: '/rosa', label: 'Rosa', match: p => p === '/rosa' };
const pathname = '/rosa';
const active = navItem.match(pathname);
console.log('active for /rosa:', active);
const classes = [
  'block px-3 py-2 rounded-xl md:rounded-lg transition',
  active ? 'bg-neutral-900 text-white' : 'text-neutral-700 hover:bg-neutral-100',
].join(' ');
console.log('classes:', classes);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b7551ccb1c8325958a47878f7ba5c1