### PR TITLE
Handle revenue registration errors

### DIFF
--- a/src/app/(protected)/stadium/page.tsx
+++ b/src/app/(protected)/stadium/page.tsx
@@ -83,18 +83,25 @@ export default function StadiumPage() {
                   <form
                     onSubmit={async (e) => {
                       e.preventDefault();
-                      const res = await registerMatchRevenue({
-                        teamId: team.id,
-                        stadiumId: stadium.id,
-                        stadiumCapacity: capacity, // ✅ number
-                        ticketPrice: price, // ✅ number
-                        attendance, // ✅ number
-                        opponent: opponent || "", // opzionale
-                        seasonId, // ✅ string
-                      });
-                      alert(
-                        `Incasso registrato: € ${res.revenue} (presenze conteggiate: ${res.cappedAttendance})`
-                      );
+                      try {
+                        const res = await registerMatchRevenue({
+                          teamId: team.id,
+                          stadiumId: stadium.id,
+                          stadiumCapacity: capacity, // ✅ number
+                          ticketPrice: price, // ✅ number
+                          attendance, // ✅ number
+                          opponent: opponent || "", // opzionale
+                          seasonId, // ✅ string
+                        });
+                        alert(
+                          `Incasso registrato: € ${res.revenue} (presenze conteggiate: ${res.cappedAttendance})`
+                        );
+                      } catch (error) {
+                        console.error("Errore nella registrazione dell'incasso", error);
+                        alert(
+                          "Si è verificato un errore durante la registrazione dell'incasso."
+                        );
+                      }
                     }}
                     className="space-y-3"
                   >


### PR DESCRIPTION
## Summary
- wrap stadium revenue registration in try/catch
- report errors via alert and console

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b75528937c83258f2af35a85f26002