### PR TITLE
chore: remove unused AppShell imports

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { db } from "@/lib/firebase";
 import { collection, doc, getDocs, orderBy, query, updateDoc } from "firebase/firestore";
-import AppShell from "@/components/AppShell";
 import Panel from "@/components/Panel";
 import { Shield } from "lucide-react";
 

--- a/src/app/(protected)/contracts/page.tsx
+++ b/src/app/(protected)/contracts/page.tsx
@@ -3,7 +3,6 @@
 import { useAuth } from "@/components/AuthProvider";
 import { useTeamData } from "@/hooks/useTeamData";
 import { addContract, renewContract, releaseContract } from "@/lib/contracts";
-import AppShell from "@/components/AppShell";
 import Panel from "@/components/Panel";
 import { RoleBadge, StatusTag } from "@/components/RoleBadge";
 import { FileText, RotateCcw, UserMinus, PlusCircle } from "lucide-react";

--- a/src/app/(protected)/rosa/page.tsx
+++ b/src/app/(protected)/rosa/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import AppShell from "@/components/AppShell";
 import Panel from "@/components/Panel";
 import Pitch from "@/components/Pitch";
 import { useTeamData } from "@/hooks/useTeamData";


### PR DESCRIPTION
## Summary
- remove unused `AppShell` imports from admin, contracts, and rosa pages

## Testing
- `npm run lint` *(fails: 104 problems (95 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b7552bce788325bd2d29c4787c5e9a