### PR TITLE
Add renewalCost unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "seed:fake": "ts-node --esm scripts/seed-fake.ts",
     "seed:standings": "ts-node --esm scripts/seed-standings.ts",
     "seed:history": "ts-node --esm scripts/seed-history.ts",
-    "import:players": "ts-node scripts/import-fg-players.ts"
+    "import:players": "ts-node scripts/import-fg-players.ts",
+    "test": "tsc src/lib/__tests__/fc.test.ts --module esnext --moduleResolution node --target ES2020 --outDir build/tests && node --test build/tests/__tests__/fc.test.js && rm -rf build"
   },
   "dependencies": {
     "csv-parse": "^6.1.0",

--- a/src/lib/__tests__/fc.test.ts
+++ b/src/lib/__tests__/fc.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { renewalCost } from '../fc.js';
+
+describe('renewalCost', () => {
+  it('calculates fee when new end is later than current end', () => {
+    const result = renewalCost(2024, 2026, 50);
+    assert.strictEqual(result, 100);
+  });
+
+  it('returns zero when new end is not later than current end', () => {
+    assert.strictEqual(renewalCost(2024, 2024, 50), 0);
+    assert.strictEqual(renewalCost(2024, 2023, 50), 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests verifying renewalCost behavior
- configure npm test script using Node's test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af05b689fc8325b80b5a2fc06d436c