### PR TITLE
Protect protected layout with AuthGate

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,7 +1,12 @@
 // src/app/(protected)/layout.tsx
 import React from "react";
 import AppShell from "@/components/AppShell";
+import AuthGate from "@/components/AuthGate";
 
 export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
-  return <AppShell>{children}</AppShell>;
+  return (
+    <AuthGate>
+      <AppShell>{children}</AppShell>
+    </AuthGate>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap protected layout inside `AuthGate` so unauthenticated users are redirected to `/login`

## Testing
- `npm test`
- `npm run lint` *(fails: 95 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b758964e58832590fd259200e63f85