### PR TITLE
Log auth state and add timeout safeguard

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -18,10 +18,23 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const off = onAuthStateChanged(auth, (u) => {
+      console.log("[AuthProvider] Auth state changed", u);
       setUser(u);
       setLoading(false);
     });
-    return () => off();
+    const timeout = setTimeout(() => {
+      setLoading((prev) => {
+        if (prev) {
+          console.warn("[AuthProvider] auth loading timeout");
+          return false;
+        }
+        return prev;
+      });
+    }, 5000);
+    return () => {
+      off();
+      clearTimeout(timeout);
+    };
   }, []);
 
   return <Ctx.Provider value={{ user, loading }}>{children}</Ctx.Provider>;


### PR DESCRIPTION
## Summary
- log user in `onAuthStateChanged`
- add 5s timeout to prevent hanging `loading` state

## Testing
- `npm run lint` (fails: Unexpected any, ...)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ea997fc083258a78275db42e775a