### PR TITLE
refactor: unmount auth gate during redirects

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -13,12 +13,16 @@ export default function AuthGate({ children }: { children: ReactNode }) {
     if (!loading && !user) router.replace("/login");
   }, [loading, user, router]);
 
-  if (loading || !user) {
+  if (loading) {
     return (
       <div className="min-h-screen grid place-items-center">
         <p>Caricamento…</p>
       </div>
     );
+  }
+
+  if (!user) {
+    return null;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- unmount AuthGate immediately when user is missing so login page shows without loader

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & ts-ignore rules across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ecbf27a48325983e3d861f84611e