### PR TITLE
feat: show login link after redirect delay

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
 
@@ -8,14 +8,31 @@ export default function Home() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
+  const [showLoginLink, setShowLoginLink] = useState(false);
+
   useEffect(() => {
     if (loading) return;
     router.replace(user ? "/dashboard" : "/login");
   }, [loading, user, router]);
 
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (loading) {
+        setShowLoginLink(true);
+      }
+    }, 5000);
+
+    return () => clearTimeout(timeout);
+  }, [loading]);
+
   return (
-    <main className="min-h-screen grid place-items-center">
+    <main className="min-h-screen grid place-items-center gap-2">
       <p>Reindirizzamento…</p>
+      {showLoginLink && (
+        <a href="/login" className="underline">
+          Vai al login
+        </a>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show a manual login link if user still loading after 5s

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ecc01fcc8325b2b3ec083d132bee