### PR TITLE
chore: remove unused admin standings link

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -40,11 +40,6 @@ export default function AppShell({ children }: Props) {
               label: 'Admin',
               match: (p) => p === '/admin',
             },
-            {
-              href: '/admin/standings',
-              label: 'Admin Classifica',
-              match: (p) => p === '/admin/standings',
-            },
           ]
         : [],
     [isAdmin]


### PR DESCRIPTION
## Summary
- remove Admin Classifica from admin navigation

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and ban-ts-comment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f5cc1a808325ab254aacf8cd6fbb