### PR TITLE
Handle missing team assignments with explicit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Admin Notes
+
+Per associare correttamente un utente a una squadra è necessario valorizzare uno dei seguenti campi nel database Firestore:
+
+- `users/{uid}.teamId`
+- `teams/{teamId}.ownerUserId`
+
+In assenza di queste informazioni l'applicazione mostrerà l'errore "Nessun team assegnato all’utente" e alcune pagine utilizzeranno valori di placeholder.

--- a/src/app/(protected)/contracts/page.tsx
+++ b/src/app/(protected)/contracts/page.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from "react";
 
 export default function ContractsPage() {
   const { user } = useAuth();
-  const { team, contracts, loading } = useTeamData();
+  const { team, contracts, loading, error } = useTeamData();
 
   const [form, setForm] = useState({
     playerName: "",
@@ -70,7 +70,11 @@ export default function ContractsPage() {
         </div>
 
         {loading && <p className="text-white/70">Caricamento…</p>}
-        {!loading && !team && <Panel title="Setup richiesto">Nessun team assegnato.</Panel>}
+        {!loading && !team && (
+          <Panel title="Setup richiesto">
+            Nessun team assegnato{error ? ` (${error})` : "."}
+          </Panel>
+        )}
 
         {!loading && team && (
           <>

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -37,22 +37,31 @@ function Section({ title, right, children, alt=false, onClick }: { title: string
   );
 }
 
-function OverviewCard({ teamName, budget, seasonId }: { teamName?: string; budget?: number; seasonId?: string | null }) {
+function OverviewCard({ teamName, budget, seasonId, error }: { teamName?: string; budget?: number; seasonId?: string | null; error?: string | null }) {
   const money = (n?: number) => (n==null? "—" : new Intl.NumberFormat("it-IT",{style:"currency",currency:"EUR",maximumFractionDigits:0}).format(n));
   return (
     <Section title="Panoramica" alt>
       <div className="grid grid-cols-2 gap-4 text-sm fm-muted">
         <div className="rounded-xl border fm-border bg-[rgba(255,255,255,0.03)] p-4">
           <div className="text-xs uppercase tracking-wider">Squadra</div>
-          <div className="mt-1 text-[var(--fm-text)] font-semibold">{teamName ?? "—"}</div>
+          <div className="mt-1 text-[var(--fm-text)] font-semibold">
+            {teamName ?? "—"}
+            {!teamName && error ? ` (${error})` : ""}
+          </div>
         </div>
         <div className="rounded-xl border fm-border bg-[rgba(255,255,255,0.03)] p-4">
           <div className="text-xs uppercase tracking-wider">Budget</div>
-          <div className="mt-1 text-[var(--fm-text)] font-semibold">{money(budget)}</div>
+          <div className="mt-1 text-[var(--fm-text)] font-semibold">
+            {budget==null ? "—" : money(budget)}
+            {budget==null && error ? ` (${error})` : ""}
+          </div>
         </div>
         <div className="rounded-xl border fm-border bg-[rgba(255,255,255,0.03)] p-4">
           <div className="text-xs uppercase tracking-wider">Stagione</div>
-          <div className="mt-1 text-[var(--fm-text)] font-semibold">{seasonId ?? "—"}</div>
+          <div className="mt-1 text-[var(--fm-text)] font-semibold">
+            {seasonId ?? "—"}
+            {!seasonId && error ? ` (${error})` : ""}
+          </div>
         </div>
         <div className="rounded-xl border fm-border bg-[rgba(255,255,255,0.03)] p-4">
           <div className="text-xs uppercase tracking-wider">Azioni rapide</div>
@@ -215,8 +224,8 @@ function TechDetailsCard(props: {
 
 export default function DashboardPage() {
   // useTeamData ora fornisce anche i contratti totali
-  const { team, contracts, loading: loadingTeam } = useTeamData();
-  console.log('[dashboard]', { team, contracts, loadingTeam });
+  const { team, contracts, loading: loadingTeam, error } = useTeamData();
+  console.log('[dashboard]', { team, contracts, loadingTeam, error });
   const teamId = useMemo(() => (team as any)?.id ?? (team as any)?.teamId ?? null, [team]);
   const seasonId = useCurrentSeasonId((team as any)?.seasonId);
 
@@ -325,9 +334,12 @@ export default function DashboardPage() {
   return (
     <>
       <div className="space-y-6">
+        {!team && error && (
+          <p className="text-red-500 text-sm">{error}</p>
+        )}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="md:col-span-2 space-y-6">
-            <OverviewCard teamName={(team as any)?.name} budget={(team as any)?.budget} seasonId={seasonId} />
+            <OverviewCard teamName={(team as any)?.name} budget={(team as any)?.budget} seasonId={seasonId} error={error} />
             {/* Nuova card con i campi richiesti */}
             <TechDetailsCard
               team={team as any}

--- a/src/hooks/useTeamData.ts
+++ b/src/hooks/useTeamData.ts
@@ -116,6 +116,7 @@ export function useTeamData() {
             setState((s) => ({
               ...s,
               loading: false,
+              error: 'Nessun team assegnato all’utente',
               teamId: null,
               data: { team: null, stadium: null, contracts: [] },
             }));


### PR DESCRIPTION
## Summary
- expose an explicit "Nessun team assegnato" error in useTeamData when a user lacks a team
- surface the error beside placeholders on dashboard and contracts pages
- document that admins must set `users/{uid}.teamId` or `teams.ownerUserId`

## Testing
- `npm run lint` *(fails: Existing code has 99 problems)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6f5174c832599e47b59dc7bee78