### PR TITLE
feat: centralize logging with debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `src/app/page.tsx`. The page auto-up
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Debug logging
+
+To enable verbose debug logs in the browser and from the custom logger utility, create a `.env.local` file and set:
+
+```
+NEXT_PUBLIC_DEBUG=1
+```
+
+When the flag is present, `FC_DEBUG` is enabled and additional `[FC]` prefixed debug messages will appear in the console.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { useCurrentSeasonId } from "@/hooks/useCurrentSeasonId";
 import { CardSkeleton } from "@/components/CardSkeleton";
 import { TableSkeleton } from "@/components/TableSkeleton";
 import DebugDock from "@/components/DebugDock";
+import logger from "@/lib/logger";
 
 type Stadium = { id: string; teamId: string; name: string; capacity: number; ticketPrice: number; imageUrl?: string; };
 type HistoryEvent = { id: string; teamId: string; seasonId?: string; kind: string; payload?: any; createdAt?: any; };
@@ -216,7 +217,7 @@ function TechDetailsCard(props: {
 export default function DashboardPage() {
   // useTeamData ora fornisce anche i contratti totali
   const { team, contracts, loading: loadingTeam } = useTeamData();
-  console.log('[dashboard]', { team, contracts, loadingTeam });
+  logger.info('[dashboard]', { team, contracts, loadingTeam });
   const teamId = useMemo(() => (team as any)?.id ?? (team as any)?.teamId ?? null, [team]);
   const seasonId = useCurrentSeasonId((team as any)?.seasonId);
 
@@ -231,7 +232,7 @@ export default function DashboardPage() {
     // @ts-ignore
     const dbg = typeof window !== "undefined" && (window as any).FC_DEBUG;
     if (!dbg) return;
-    console.debug("[FC][dashboard] state", {
+    logger.debug('[dashboard] state', {
       teamId,
       seasonId,
       loadingTeam,
@@ -254,7 +255,7 @@ export default function DashboardPage() {
   const watchdog = setTimeout(() => {
     // @ts-ignore
     if (typeof window !== "undefined" && (window as any).FC_DEBUG) {
-      console.warn("[FC][dashboard] history taking >4000ms", { teamId });
+      logger.warn('[dashboard] history taking >4000ms', { teamId });
     }
   }, 4000);
 
@@ -272,13 +273,13 @@ export default function DashboardPage() {
       console.timeEnd("[FC][dashboard] history");
       // @ts-ignore
       if (typeof window !== "undefined" && (window as any).FC_DEBUG) {
-        console.debug("[FC][dashboard] history snapshot", { count: rows.length });
+        logger.debug('[dashboard] history snapshot', { count: rows.length });
       }
       clearTimeout(watchdog);
     },
     (err) => {
       console.timeEnd("[FC][dashboard] history");
-      console.error("[FC][dashboard] history ERROR", err);
+      logger.error('[dashboard] history ERROR', err);
       setLoadingEvents(false);
       clearTimeout(watchdog);
     }

--- a/src/app/(protected)/stadium/page.tsx
+++ b/src/app/(protected)/stadium/page.tsx
@@ -5,6 +5,7 @@ import Panel from "@/components/Panel";
 import { Building2 } from "lucide-react";
 import { useState } from "react";
 import { registerMatchRevenue } from "@/lib/revenue";
+import logger from "@/lib/logger";
 
 export default function StadiumPage() {
   const { team, stadium, loading } = useTeamData();
@@ -97,7 +98,7 @@ export default function StadiumPage() {
                           `Incasso registrato: € ${res.revenue} (presenze conteggiate: ${res.cappedAttendance})`
                         );
                       } catch (error) {
-                        console.error("Errore nella registrazione dell'incasso", error);
+                        logger.error("Errore nella registrazione dell'incasso", error);
                         alert(
                           "Si è verificato un errore durante la registrazione dell'incasso."
                         );

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -4,6 +4,7 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from "react";
 import { onAuthStateChanged, User } from "firebase/auth";
 import { auth } from "@/lib/firebase";
+import logger from "@/lib/logger";
 
 type AuthCtx = { user: User | null; loading: boolean };
 const Ctx = createContext<AuthCtx>({ user: null, loading: true });
@@ -20,22 +21,22 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     let off: (() => void) | undefined;
     try {
       off = onAuthStateChanged(auth, (u) => {
-        console.log("[AuthProvider] Auth state changed", u);
+        logger.info("[AuthProvider] Auth state changed", u);
         setUser(u);
         setLoading(false);
       });
     } catch (error) {
-      console.error("[AuthProvider] onAuthStateChanged error", error);
+      logger.error("[AuthProvider] onAuthStateChanged error", error);
       setLoading(false);
     }
     if (!off) {
-      console.error("[AuthProvider] onAuthStateChanged did not return a handler");
+      logger.error("[AuthProvider] onAuthStateChanged did not return a handler");
       setLoading(false);
     }
     const timeout = setTimeout(() => {
       setLoading((prev) => {
         if (prev) {
-          console.warn("[AuthProvider] auth loading timeout");
+          logger.warn("[AuthProvider] auth loading timeout");
           return false;
         }
         return prev;

--- a/src/hooks/useExpiringContracts.ts
+++ b/src/hooks/useExpiringContracts.ts
@@ -12,6 +12,7 @@ import {
   where,
   DocumentData,
 } from 'firebase/firestore';
+import logger from '@/lib/logger';
 
 export type Contract = {
   id: string;
@@ -24,12 +25,7 @@ export type Contract = {
   status: string;  // 'active' | 'released' | ...
 };
 
-const DBG = (...args: any[]) => {
-  // @ts-ignore
-  if (typeof window !== 'undefined' && (window as any).FC_DEBUG) {
-    console.debug('[FC][useExpiringContracts]', ...args);
-  }
-};
+const DBG = (...args: unknown[]) => logger.debug('[useExpiringContracts]', ...args);
 
 export function useExpiringContracts(teamId?: string, seasonId?: string) {
   const [data, setData] = useState<Contract[]>([]);
@@ -89,7 +85,7 @@ export function useExpiringContracts(teamId?: string, seasonId?: string) {
         DBG('got', rows.length);
       },
       (err) => {
-        console.error('[FC][useExpiringContracts] ERROR', err);
+        logger.error('[useExpiringContracts] ERROR', err);
         setError(err.message ?? String(err));
         setLoading(false);
       }

--- a/src/hooks/useStadium.ts
+++ b/src/hooks/useStadium.ts
@@ -12,6 +12,7 @@ import {
   Unsubscribe,
   DocumentData,
 } from 'firebase/firestore';
+import logger from '@/lib/logger';
 
 type StadiumDoc = {
   teamId: string;
@@ -21,12 +22,7 @@ type StadiumDoc = {
   imageUrl?: string;
 };
 
-const DBG = (...args: any[]) => {
-  // @ts-ignore
-  if (typeof window !== 'undefined' && (window as any).FC_DEBUG) {
-    console.debug('[FC][useStadium]', ...args);
-  }
-};
+const DBG = (...args: unknown[]) => logger.debug('[useStadium]', ...args);
 
 export function useStadium(teamId?: string) {
   const [stadium, setStadium] = useState<(StadiumDoc & { id: string }) | null>(null);
@@ -75,7 +71,7 @@ export function useStadium(teamId?: string) {
         setLoading(false);
       },
       (err) => {
-        console.error('[FC][useStadium] ERROR', err);
+        logger.error('[useStadium] ERROR', err);
         setError(err.message ?? String(err));
         setLoading(false);
       }

--- a/src/hooks/useTeamData.ts
+++ b/src/hooks/useTeamData.ts
@@ -16,6 +16,7 @@ import {
   onSnapshot,
   Unsubscribe,
 } from 'firebase/firestore';
+import logger from '@/lib/logger';
 
 export type TeamDoc = { name: string; seasonId?: string; ownerUserId?: string; stadiumId?: string; [k: string]: unknown };
 export type StadiumDoc = { teamId: string; name: string; capacity?: number; ticketPrice?: number };
@@ -35,12 +36,7 @@ type State = {
   data: TeamData;
 };
 
-const DBG = (...args: unknown[]) => {
-  // stampa solo se flag attivo
-  // @ts-expect-error FC_DEBUG is a debug flag attached to window at runtime
-  if (typeof window !== 'undefined' && (window as { FC_DEBUG?: boolean }).FC_DEBUG)
-    console.debug('[FC][useTeamData]', ...args);
-};
+const DBG = (...args: unknown[]) => logger.debug('[useTeamData]', ...args);
 
 export function useTeamData() {
   const [state, setState] = useState<State>({
@@ -157,7 +153,7 @@ export function useTeamData() {
                     }));
                 },
                 (err) => {
-                  console.error('[FC][useTeamData]', err);
+                  logger.error('[useTeamData]', err);
                   if (alive.current && !cancelled)
                     setState((s) => ({
                       ...s,
@@ -189,7 +185,7 @@ export function useTeamData() {
                     }));
                 },
                 (err) => {
-                  console.error('[FC][useTeamData]', err);
+                  logger.error('[useTeamData]', err);
                   if (alive.current && !cancelled)
                     setState((s) => ({
                       ...s,
@@ -201,7 +197,7 @@ export function useTeamData() {
             }
           },
           (err) => {
-            console.error('[FC][useTeamData]', err);
+            logger.error('[useTeamData]', err);
             if (alive.current && !cancelled)
               setState((s) => ({
                 ...s,
@@ -234,7 +230,7 @@ export function useTeamData() {
               }));
           },
           (err) => {
-            console.error('[FC][useTeamData]', err);
+            logger.error('[useTeamData]', err);
             if (alive.current && !cancelled)
               setState((s) => ({
                 ...s,
@@ -244,7 +240,7 @@ export function useTeamData() {
           }
         );
       } catch (e: unknown) {
-        console.error('[FC][useTeamData] ERROR', e);
+        logger.error('[useTeamData] ERROR', e);
         if (alive.current && !cancelled)
           setState((s) => ({
             ...s,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,6 +3,13 @@ import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore, setLogLevel } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
+import logger from "@/lib/logger";
+
+declare global {
+  interface Window {
+    FC_DEBUG?: boolean;
+  }
+}
 
 
 const firebaseConfig = {
@@ -22,7 +29,6 @@ export const storage = getStorage(app); // <-- aggiunto
 
 // 🔧 DEBUG: abilita log verbosi quando NEXT_PUBLIC_DEBUG=1
 if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_DEBUG === "1") {
-  // @ts-ignore
-  (window as any).FC_DEBUG = true;
+  window.FC_DEBUG = true;
   setLogLevel("debug"); // log firestore su console
-  console.info("[FC][firebase] Firestore logLevel=debug attivo");}
+  logger.info("[firebase] Firestore logLevel=debug attivo");}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,29 @@
+const PREFIX = '[FC]';
+
+function isDebugEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return Boolean((window as unknown as { FC_DEBUG?: boolean }).FC_DEBUG);
+  }
+  return process.env.NEXT_PUBLIC_DEBUG === '1';
+}
+
+export function debug(...args: unknown[]) {
+  if (isDebugEnabled()) {
+    console.debug(PREFIX, ...args);
+  }
+}
+
+export function info(...args: unknown[]) {
+  console.info(PREFIX, ...args);
+}
+
+export function warn(...args: unknown[]) {
+  console.warn(PREFIX, ...args);
+}
+
+export function error(...args: unknown[]) {
+  console.error(PREFIX, ...args);
+}
+
+const logger = { debug, info, warn, error };
+export default logger;


### PR DESCRIPTION
## Summary
- add logger utility respecting FC_DEBUG and prefixing messages with [FC]
- replace console logging with centralized logger in hooks and protected pages
- document enabling debug via `.env.local` using `NEXT_PUBLIC_DEBUG=1`

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6f66244832580b1ee8389c87cbe