### PR TITLE
Add logout handler and test redirect to login

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "seed:standings": "ts-node --esm scripts/seed-standings.ts",
     "seed:history": "ts-node --esm scripts/seed-history.ts",
     "import:players": "ts-node scripts/import-fg-players.ts",
-    "test": "tsc src/lib/__tests__/fc.test.ts --module esnext --moduleResolution node --target ES2020 --outDir build/tests && node --test build/tests/__tests__/fc.test.js && rm -rf build"
+    "test": "rm -rf build && tsc src/**/__tests__/*.ts --module esnext --moduleResolution node --target ES2020 --jsx react-jsx --outDir build/tests && node --test build/tests/**/__tests__/*.js && rm -rf build"
   },
   "dependencies": {
     "csv-parse": "^6.1.0",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { ReactNode, useMemo } from 'react';
 import { useUserRole } from '@/hooks/useUserRole';
 import { signOut } from '@/lib/auth';
+import { handleLogout } from '@/lib/logout';
 
 type Props = {
   children: ReactNode;
@@ -95,10 +96,7 @@ export default function AppShell({ children }: Props) {
               <span>v1.0</span>
               <button
                 className="px-2 py-1 rounded-md border hover:bg-neutral-100"
-                onClick={async () => {
-                  await signOut();
-                  router.replace('/login');
-                }}
+                onClick={() => handleLogout(router, signOut)}
               >
                 Esci
               </button>

--- a/src/components/__tests__/AppShell.test.ts
+++ b/src/components/__tests__/AppShell.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { handleLogout } from '../../lib/logout.js';
+
+describe('handleLogout', () => {
+  it('signs out and redirects to /login', async () => {
+    let replaced = '';
+    let signOutCalled = false;
+    const router = { replace: (url: string) => { replaced = url; } };
+    const fakeSignOut = async () => { signOutCalled = true; };
+
+    await handleLogout(router, fakeSignOut);
+
+    assert.ok(signOutCalled);
+    assert.equal(replaced, '/login');
+  });
+});

--- a/src/lib/logout.ts
+++ b/src/lib/logout.ts
@@ -1,0 +1,7 @@
+export async function handleLogout(
+  router: { replace: (url: string) => void },
+  signOutFn: () => Promise<void>
+) {
+  await signOutFn();
+  router.replace('/login');
+}


### PR DESCRIPTION
## Summary
- expose `handleLogout` helper to centralize sign out flow
- test logout redirects the user to `/login`
- run tests with a dedicated script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6f71eac8325b0134432bd78ab6a