### PR TITLE
refactor: clean dashboard team data init

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -225,12 +225,8 @@ function TechDetailsCard(props: {
 
 export default function DashboardPage() {
   // useTeamData ora fornisce anche i contratti totali
-codex/add-explicit-error-message-in-useteamdata
   const { team, contracts, loading: loadingTeam, error } = useTeamData();
   logger.info('[dashboard]', { team, contracts, loadingTeam, error });
-  const { team, contracts, loading: loadingTeam } = useTeamData();
-  logger.info('[dashboard]', { team, contracts, loadingTeam });
-main
   const teamId = useMemo(() => (team as any)?.id ?? (team as any)?.teamId ?? null, [team]);
   const seasonId = useCurrentSeasonId((team as any)?.seasonId);
 


### PR DESCRIPTION
## Summary
- remove codex marker and duplicate `useTeamData` destructure in dashboard page
- retain single `useTeamData` call and log

## Testing
- `npm test`
- `npm run build` *(fails: Unexpected any from eslint across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fe42263883258013116dfd980427