### PR TITLE
Add Firestore rules for authenticated team access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,24 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function canRead(data) {
+      return request.auth != null && (data.ownerUserId == request.auth.uid || data.teamId == request.auth.uid);
+    }
+
+    match /users/{userId} {
+      allow read: if canRead(resource.data);
+    }
+
+    match /teams/{teamId} {
+      allow read: if canRead(resource.data);
+    }
+
+    match /stadiums/{stadiumId} {
+      allow read: if canRead(resource.data);
+    }
+
+    match /contracts/{contractId} {
+      allow read: if canRead(resource.data);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules to allow authenticated users to read `users`, `teams`, `stadiums`, and `contracts` when their UID matches `ownerUserId` or `teamId`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b802200d108325ac4ed35c533f49ce