### PR TITLE
Handle Firestore permission-denied errors and surface alerts

### DIFF
--- a/src/app/(protected)/contracts/page.tsx
+++ b/src/app/(protected)/contracts/page.tsx
@@ -69,6 +69,11 @@ export default function ContractsPage() {
           <p className="text-white/60 text-xs sm:text-sm">{user?.email}</p>
         </div>
 
+        {error && (
+          <div className="bg-red-500 text-white px-4 py-2 rounded" role="alert">
+            {error}
+          </div>
+        )}
         {loading && <p className="text-white/70">Caricamento…</p>}
         {!loading && !team && (
           <Panel title="Setup richiesto">

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -335,8 +335,10 @@ export default function DashboardPage() {
   return (
     <>
       <div className="space-y-6">
-        {!team && error && (
-          <p className="text-red-500 text-sm">{error}</p>
+        {error && (
+          <div className="bg-red-500 text-white px-4 py-2 rounded" role="alert">
+            {error}
+          </div>
         )}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="md:col-span-2 space-y-6">

--- a/src/app/(protected)/history/page.tsx
+++ b/src/app/(protected)/history/page.tsx
@@ -15,7 +15,7 @@ type EventRow = {
 };
 
 export default function HistoryPage() {
-  const { team, loading } = useTeamData();
+  const { team, loading, error } = useTeamData();
   const [rows, setRows] = useState<EventRow[]>([]);
   const [eventsLoading, setEventsLoading] = useState(true);
 
@@ -43,6 +43,11 @@ export default function HistoryPage() {
           </h1>
         </div>
 
+        {error && (
+          <div className="bg-red-500 text-white px-4 py-2 rounded" role="alert">
+            {error}
+          </div>
+        )}
         {loading && <p className="text-white/70">Caricamento…</p>}
         {!loading && !team && (
           <Panel title="Setup richiesto">Nessun team assegnato.</Panel>

--- a/src/app/(protected)/rosa/page.tsx
+++ b/src/app/(protected)/rosa/page.tsx
@@ -8,7 +8,7 @@ import { Users } from "lucide-react";
 import { useMemo } from "react";
 
 export default function RosaPage() {
-  const { team, contracts, loading } = useTeamData();
+  const { team, contracts, loading, error } = useTeamData();
 
   // Ordina per ruolo (P, D, C, A) e poi alfabetico giocatore
   const rows = useMemo(() => {
@@ -31,6 +31,11 @@ export default function RosaPage() {
           </h1>
           {team && <span className="text-white/60 text-xs sm:text-sm">{team.name}</span>}
         </div>
+        {error && (
+          <div className="bg-red-500 text-white px-4 py-2 rounded" role="alert">
+            {error}
+          </div>
+        )}
 
         {/* layout 2 colonne: sinistra campo, destra tabella */}
         <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">

--- a/src/app/(protected)/stadium/page.tsx
+++ b/src/app/(protected)/stadium/page.tsx
@@ -8,7 +8,7 @@ import { registerMatchRevenue } from "@/lib/revenue";
 import logger from "@/lib/logger";
 
 export default function StadiumPage() {
-  const { team, stadium, loading } = useTeamData();
+  const { team, stadium, loading, error } = useTeamData();
   const [attendance, setAttendance] = useState<number>(10000);
   const [opponent, setOpponent] = useState<string>("");
 
@@ -21,6 +21,11 @@ export default function StadiumPage() {
         </h1>
       </div>
 
+      {error && (
+        <div className="bg-red-500 text-white px-4 py-2 rounded" role="alert">
+          {error}
+        </div>
+      )}
       {loading && <p className="text-white/70">Caricamento…</p>}
       {!loading && !team && (
         <Panel title="Setup richiesto">Nessun team assegnato.</Panel>

--- a/src/hooks/useTeamData.ts
+++ b/src/hooks/useTeamData.ts
@@ -68,6 +68,16 @@ export function useTeamData() {
     let stadiumUnsub: Unsubscribe | null = null;
     let contractsUnsub: Unsubscribe | null = null;
 
+    const handleError = (err: unknown) => {
+      logger.error('[useTeamData]', err);
+      const e = err as { code?: string; message?: string };
+      const message = e.code === 'permission-denied'
+        ? 'Permessi insufficienti, contatta l’amministratore'
+        : e.message ?? String(err);
+      if (alive.current && !cancelled)
+        setState((s) => ({ ...s, loading: false, error: message }));
+    };
+
     (async () => {
       try {
         if (alive.current && !cancelled)
@@ -153,15 +163,7 @@ export function useTeamData() {
                       data: { ...s.data, stadium },
                     }));
                 },
-                (err) => {
-                  logger.error('[useTeamData]', err);
-                  if (alive.current && !cancelled)
-                    setState((s) => ({
-                      ...s,
-                      loading: false,
-                      error: err.message,
-                    }));
-                }
+                (err) => handleError(err)
               );
             } else {
               const stQ = query(
@@ -185,27 +187,11 @@ export function useTeamData() {
                       data: { ...s.data, stadium },
                     }));
                 },
-                (err) => {
-                  logger.error('[useTeamData]', err);
-                  if (alive.current && !cancelled)
-                    setState((s) => ({
-                      ...s,
-                      loading: false,
-                      error: err.message,
-                    }));
-                }
+                (err) => handleError(err)
               );
             }
           },
-          (err) => {
-            logger.error('[useTeamData]', err);
-            if (alive.current && !cancelled)
-              setState((s) => ({
-                ...s,
-                loading: false,
-                error: err.message,
-              }));
-          }
+          (err) => handleError(err)
         );
 
         // 5) contracts
@@ -230,24 +216,10 @@ export function useTeamData() {
                 data: { ...s.data, contracts },
               }));
           },
-          (err) => {
-            logger.error('[useTeamData]', err);
-            if (alive.current && !cancelled)
-              setState((s) => ({
-                ...s,
-                loading: false,
-                error: err.message,
-              }));
-          }
+          (err) => handleError(err)
         );
       } catch (e: unknown) {
-        logger.error('[useTeamData] ERROR', e);
-        if (alive.current && !cancelled)
-          setState((s) => ({
-            ...s,
-            loading: false,
-            error: e instanceof Error ? e.message : String(e),
-          }));
+        handleError(e);
       }
     })();
 


### PR DESCRIPTION
## Summary
- Handle Firestore `permission-denied` errors in `useTeamData` with a user-friendly message
- Display hook errors in prominent alerts across dashboard, contracts, squad, history, and stadium pages

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b80220f22c8325a7bbc1d35249454f